### PR TITLE
Update script.php

### DIFF
--- a/script.php
+++ b/script.php
@@ -15,7 +15,8 @@ class  joomla3eolsecurityfixesInstallerScript
 
 
         // Get the "files" directory path from the plugin's installation package
-        $sourcePath = $parent->getParent()->getPath('source') . '/files';
+        // On Windows we have to use realpath() because of backslashes in the PATH or it will give the error "original File not found"...
+        $sourcePath = realpath($parent->getParent()->getPath('source') . '/files');
 
         // Define the root path of your Joomla installation
         $rootPath = JPATH_ROOT;


### PR DESCRIPTION
When installing the plugin on a Windows server, it'll give an error of "original File not found" because of backslashes in the path.

Using the realpath() function will solve the problem on Windows.