### PR TITLE
Security Update: April 2026 Backports (v1.0.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Joomla 3 EOL Security Fixes 
 This plugin will help you update the files associated with the known security fixes as listed below.
-It will overwrite the files and then auto uninstalls itself again. 
+It will overwrite the files and then auto uninstalls itself again.
+
+## Version 1.0.10 fixes the below security issues (it also contains all previous versions fixes)
+- [20260301] — Core — ACL hardening in com_ajax (CVE-2026-21629). More info: https://developer.joomla.org/security-centre/1018-20260301-core-acl-hardening-in-com_ajax.html
+- [20260303] — Core — XSS vector in com_associations comparison view (CVE-2026-21631). More info: https://developer.joomla.org/security-centre/1020-20260303-core-xss-vector-in-com_associations.html
 
 ## Version 1.0.9 fixes the below security issues (it also contains all previous versions fixes)
 - [20260102] — Core — XSS vector in the pagebreak plugin (CVE-2025-63083). More info: https://developer.joomla.org/security-centre/1017-20260102-core-xss-vector-in-the-pagebreak-plugin.html

--- a/files/administrator/components/com_ajax/ajax.php
+++ b/files/administrator/components/com_ajax/ajax.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_ajax
+ *
+ * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+// --- 2026 SECURITY BACKPORT START (CVE-2026-21629) ---
+// Prevent unauthorized access to the ajax component in the backend
+if (!JFactory::getUser()->authorise('core.manage', 'com_ajax')) {
+	throw new Exception(JText::_('JERROR_ALERTNOAUTHOR'), 403);
+}
+// --- 2026 SECURITY BACKPORT END ---
+
+require_once JPATH_SITE . '/components/com_ajax/ajax.php';

--- a/files/administrator/components/com_associations/views/association/tmpl/edit.php
+++ b/files/administrator/components/com_associations/views/association/tmpl/edit.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_associations
+ *
+ * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+JHtml::_('behavior.formvalidator');
+JHtml::_('behavior.keepalive');
+JHtml::_('formbehavior.chosen', 'select');
+
+JHtml::_('script', 'com_associations/sidebyside.js', false, true);
+JHtml::_('stylesheet', 'com_associations/sidebyside.css', array(), true);
+
+$options = array(
+			'layout'   => $this->app->input->get('layout', '', 'string'),
+			'itemtype' => $this->itemtype,
+			'id'       => $this->referenceId,
+		);
+?>
+<button id="toogle-left-panel" class="btn btn-small"
+		data-show-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_SHOW_REFERENCE'); ?>"
+		data-hide-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>"><?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>
+</button>
+
+<form action="<?php echo JRoute::_('index.php?option=com_associations&view=association&' . http_build_query($options)); ?>" method="post" name="adminForm" id="adminForm" data-associatedview="<?php echo $this->typeName; ?>">
+	<div class="sidebyside">
+		<div class="outer-panel" id="left-panel">
+			<div class="inner-panel">
+				<h3><?php echo JText::_('COM_ASSOCIATIONS_REFERENCE_ITEM'); ?></h3>
+				<iframe id="reference-association" name="reference-association" title="reference-association"
+					src="<?php echo JRoute::_($this->editUri . '&task=' . $this->typeName . '.edit&id=' . (int) $this->referenceId); ?>"
+					height="400" width="400"
+					data-action="edit"
+					data-item="<?php echo $this->typeName; ?>"
+					data-id="<?php echo $this->referenceId; ?>"
+					data-title="<?php echo $this->escape($this->referenceTitle); ?>"
+					data-title-value="<?php echo $this->escape($this->referenceTitleValue); ?>"
+					data-language="<?php echo $this->referenceLanguage; ?>"
+					data-editurl="<?php echo JRoute::_($this->editUri); ?>">
+				</iframe>
+			</div>
+		</div>
+		<div class="outer-panel" id="right-panel">
+			<div class="inner-panel">
+				<div class="language-selector">
+					<h3 class="target-text"><?php echo JText::_('COM_ASSOCIATIONS_ASSOCIATED_ITEM'); ?></h3>
+					<?php echo $this->form->getInput('modalassociation'); ?>
+					<?php echo $this->form->getInput('itemlanguage'); ?>
+				</div>
+				<iframe id="target-association" name="target-association" title="target-association"
+					src="<?php echo $this->defaultTargetSrc; ?>"
+					height="400" width="400"
+					data-action="<?php echo $this->targetAction; ?>"
+					data-item="<?php echo $this->typeName; ?>"
+					data-id="<?php echo $this->targetId; ?>"
+					data-title="<?php echo $this->escape($this->targetTitle); ?>"
+					data-language="<?php echo $this->targetLanguage; ?>"
+					data-editurl="<?php echo JRoute::_($this->editUri); ?>">
+				</iframe>
+			</div>
+		</div>
+
+	</div>
+
+	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="target-id" id="target-id" value="" />
+	<?php echo JHtml::_('form.token'); ?>
+</form>

--- a/files/libraries/src/Version.php
+++ b/files/libraries/src/Version.php
@@ -4,7 +4,7 @@
  *
  * @copyright  (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
- * Updated January 2026 by N8 Solutions to include EOL security backports.
+ * Updated April 2026 by N8 Solutions to include v1.0.10 EOL security backports.
  */
 
 namespace Joomla\CMS;
@@ -61,7 +61,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    const EXTRA_VERSION = '2026-01-08-EOLfix';
+    const EXTRA_VERSION = '2026-04-19-EOLfix';
 
     /**
      * Release version.

--- a/joomla3eolsecurityfixes.xml
+++ b/joomla3eolsecurityfixes.xml
@@ -2,8 +2,8 @@
 <extension type="file" version="3.10" method="upgrade">
     <name>Joomla 3 EOL Security Fixes (2026 Update)</name>
     <author>Tom van der Laan || TLWebdesign (Updated by N8Solutions)</author>
-    <creationDate>2026-01-08</creationDate>
-    <version>1.0.9</version>
+    <creationDate>2026-04-19</creationDate>
+    <version>1.0.10</version>
     <description><![CDATA[This plugin fixes all known vulnerabilities (as of the release of this plugin) in Joomla 3.10.12. After applying the fix it auto-uninstalls itself.]]></description>
     <scriptfile>script.php</scriptfile>
 </extension>

--- a/script.php
+++ b/script.php
@@ -4,7 +4,7 @@
  * @author      TLWebdesign (Original)
  * @maintainer  N8 Solutions (2026 Security Backports)
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * Updated January 2026 by N8 Solutions to include EOL security backports.
+ * Updated April 2026 by N8 Solutions to include v1.0.10 EOL security backports.
  */
 
 defined('_JEXEC') or die;
@@ -64,7 +64,7 @@ class joomla3eolsecurityfixesInstallerScript
     public function postflight($type, $parent)
     {
         // Simple, cumulative success message
-        Factory::getApplication()->enqueueMessage("<h2>Joomla 3.10.12 Hardened Successfully</h2><p>All known core vulnerabilities (including 2024-2026 backports) have been patched. The system is now secure.</p>", 'message');
+        Factory::getApplication()->enqueueMessage("<h2>Joomla 3.10.12 Hardened Successfully (v1.0.10)</h2><p>All known core vulnerabilities (including 2024-2026 backports) have been patched. The system is now secure.</p>", 'message');
 
         // Remove this plugin to leave no trace (self-uninstall)
         $this->uninstallPlugin();


### PR DESCRIPTION
Hi Tom,

Following up on our v1.0.9 release, this Pull Request updates the extension to **v1.0.10** to address two new vulnerabilities disclosed in the March/April 2026 (Joomla 6.0.4 / 5.4.4) security updates. 

Because these vulnerabilities affect files not previously included in your repo, this PR introduces two newly patched core files to the `/files` directory:

1. **`files/administrator/components/com_ajax/ajax.php`**
   - **[20260301] (CVE-2026-21629):** The legacy `com_ajax` backend entry point lacks an ACL check, allowing unauthorized execution. Added standard `core.manage` authorization.

2. **`files/administrator/components/com_associations/views/association/tmpl/edit.php`**
   - **[20260303] (CVE-2026-21631):** The `com_associations` side-by-side edit view passes unescaped data directly into the iframe `data-title` attributes. Added `$this->escape()` wrappers around the referenceTitle, referenceTitleValue, and targetTitle variables.

*(Note: I also reviewed the other XSS/Webservices CVEs from this release, but verified they do not apply to the legacy Joomla 3 architecture, so they are intentionally excluded).*