### PR TITLE
Fix: Realign Internal Versioning and Success Messaging (v1.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 This plugin will help you update the files associated with the known security fixes as listed below.
 It will overwrite the files and then auto uninstalls itself again.
 
+## Version 1.1.2 fixes the below update issues (it also contains all previous versions fixes)
+- [20260528] — Infrastructure — Realigned the internal XML manifest and installer scripts to v1.1.2 to force a clean update path. This ensures the Joomla updater successfully applies the files, updates the success messages, and correctly displays the new version in the backend footer.
+
 ## Version 1.0.11 fixes the below security issues (it also contains all previous versions fixes)
 - [20260501] — Core — XSS in feed modules (CVE-2026-25900). More info: https://developer.joomla.org/security-centre/1033-20260501-core-xss-in-feed-modules.html
 - [20260503] — Core — XSS in com_contenthistory (CVE-2026-30894). More info: https://developer.joomla.org/security-centre/1035-20260503-core-xss-in-com-contenthistory

--- a/files/libraries/src/Version.php
+++ b/files/libraries/src/Version.php
@@ -4,7 +4,8 @@
  *
  * @copyright  (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
- * Updated April 2026 by N8 Solutions to include v1.0.10 EOL security backports.
+ * Updated May 2026 by TLWebdesign to include latest security backports.
+ * Updated May 2026 by N8 Solutions to realign internal versioning (v1.1.2).
  */
 
 namespace Joomla\CMS;
@@ -61,7 +62,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    const EXTRA_VERSION = '2026-05-26-EOLfix';
+    const EXTRA_VERSION = '2026-05-28-EOLfix';
 
     /**
      * Release version.

--- a/joomla3eolsecurityfixes.xml
+++ b/joomla3eolsecurityfixes.xml
@@ -2,8 +2,8 @@
 <extension type="file" version="3.10" method="upgrade">
     <name>Joomla 3 EOL Security Fixes (2026 Update)</name>
     <author>Tom van der Laan || TLWebdesign (Updated by N8Solutions)</author>
-    <creationDate>2026-05-26</creationDate>
-    <version>1.0.11</version>
+    <creationDate>2026-05-28</creationDate>
+    <version>1.1.2</version>
     <description><![CDATA[This plugin fixes all known vulnerabilities (as of the release of this plugin) in Joomla 3.10.12. After applying the fix it auto-uninstalls itself.]]></description>
     <scriptfile>script.php</scriptfile>
 </extension>

--- a/script.php
+++ b/script.php
@@ -5,6 +5,7 @@
  * @maintainer  N8 Solutions & TLWebdesign (2026 Security Backports)
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  * Updated May 2026 by TLWebdesign to include latest security backports.
+ * Updated May 2026 by N8 Solutions to realign internal versioning (v1.1.2).
  */
 
 defined('_JEXEC') or die;
@@ -64,7 +65,7 @@ class joomla3eolsecurityfixesInstallerScript
     public function postflight($type, $parent)
     {
         // Simple, cumulative success message
-        Factory::getApplication()->enqueueMessage("<h2>Joomla 3.10.12 Hardened Successfully (v1.0.11)</h2><p>All known core vulnerabilities (including 2024-2026 backports) have been patched. The system is now secure.</p>", 'message');
+        Factory::getApplication()->enqueueMessage("<h2>Joomla 3.10.12 Hardened Successfully (v1.1.2)</h2><p>All known core vulnerabilities up to and including the May 2026 backports have been patched. The system is now secure.</p>", 'message');
 
         // Remove this plugin to leave no trace (self-uninstall)
         $this->uninstallPlugin();


### PR DESCRIPTION
Hi Tom,

Just a quick heads-up to help sync the internal versioning with the recent releases. 

When my previous PR for `v1.0.10` was merged and published under the new `V1.1.0` tag, the internal tracking numbers didn't get bumped to match the new public release. 

While the security patches themselves are installing perfectly, the internal `joomla3eolsecurityfixes.xml` was left behind, and the installer success messages weren't matching the public tags. Because of this, users aren't seeing the updated version in the Joomla footer, making it difficult for admins to verify they have the latest build installed.

To completely clean up the administrative paper trail, this PR brings all the internal files up to **`v1.1.2`** so they mathematically clear the previous tags:
- Bumped `joomla3eolsecurityfixes.xml` to `v1.1.2`.
- Updated `script.php` success messages to explicitly confirm `v1.1.2` and clarify that all known core vulnerabilities up to the May 2026 backports are included.
- Updated `Version.php` `EXTRA_VERSION` constant to `2026-05-28-EOLfix` to provide a clear, visible confirmation in the Joomla backend footer.

This ensures the GitHub tag, the XML manifest, the installer pop-up, and the site footer are all giving the user the exact same information. 

Thanks again for managing these releases!