### PR TITLE
Fix double-encoding bug in mod_feed feed title URL (v1.1.1)

### DIFF
--- a/files/administrator/modules/mod_feed/tmpl/default.php
+++ b/files/administrator/modules/mod_feed/tmpl/default.php
@@ -56,7 +56,7 @@ else
 		// Feed title
 		if (!is_null($feed->title) && $params->get('rsstitle', 1)) : ?>
 			<h2 class="<?php echo $direction; ?>">
-				<a href="<?php echo htmlspecialchars(str_replace('&', '&amp;', $rssurl), ENT_QUOTES, 'UTF-8'); ?>" target="_blank">
+				<a href="<?php echo htmlspecialchars($rssurl, ENT_QUOTES, 'UTF-8'); ?>" target="_blank">
 				<?php echo htmlspecialchars($feed->title, ENT_QUOTES, 'UTF-8'); ?></a>
 			</h2>
 		<?php endif;


### PR DESCRIPTION
While merging release v1.1.1 into my Joomla 3 fork, I had a coding agent review the incoming changes. It identified a bug introduced by the security patch in administrator/modules/mod_feed/tmpl/default.php. Thanks to everyone for the great work on this extension — flagging this in the hope it helps.

The bug — double-encoded ampersands in feed title URL (line 59)

The patch wraps the existing str_replace('&', '&amp;', $rssurl) call inside htmlspecialchars(...):

`echo htmlspecialchars(str_replace('&', '&amp;', $rssurl), ENT_QUOTES, 'UTF-8');`
This double-encodes ampersands: str_replace converts & → &amp;, then htmlspecialchars re-encodes the & in &amp; → &amp;amp;. Any feed URL with query-string parameters breaks — ?foo=1&bar=2 renders as ?foo=1&amp;amp;bar=2.

Fix

Drop the redundant str_replace entirely. htmlspecialchars already handles & correctly on its own, and also covers " and ' that str_replace never did:

`echo htmlspecialchars($rssurl, ENT_QUOTES, 'UTF-8');`